### PR TITLE
feat(checkpoints): gate skill on Docker artefact presence

### DIFF
--- a/skills/docker-development/checkpoints.yaml
+++ b/skills/docker-development/checkpoints.yaml
@@ -4,6 +4,13 @@
 version: 1
 skill_id: docker-development
 
+# Only run this skill for repos that actually use Docker. Without this gate
+# the skill reports Dockerfile/compose errors against TYPO3 extensions,
+# libraries, skill repos, and other non-containerised projects.
+preconditions:
+  - type: command
+    pattern: "test -f Dockerfile -o -f Containerfile -o -f docker-compose.yml -o -f docker-compose.yaml -o -f compose.yml -o -f compose.yaml -o -f docker-bake.hcl"
+
 mechanical:
   # === DOCKERFILE/COMPOSE EXISTENCE ===
   - id: DC-01

--- a/skills/docker-development/checkpoints.yaml
+++ b/skills/docker-development/checkpoints.yaml
@@ -7,9 +7,11 @@ skill_id: docker-development
 # Only run this skill for repos that actually use Docker. Without this gate
 # the skill reports Dockerfile/compose errors against TYPO3 extensions,
 # libraries, skill repos, and other non-containerised projects.
+# Uses chained `||` (not `test -o`, which is obsolescent in POSIX) and matches
+# the patterns the existing checkpoints look for.
 preconditions:
   - type: command
-    pattern: "test -f Dockerfile -o -f Containerfile -o -f docker-compose.yml -o -f docker-compose.yaml -o -f compose.yml -o -f compose.yaml -o -f docker-bake.hcl"
+    pattern: "test -f Dockerfile || test -f Containerfile || test -f docker-compose.yml || test -f docker-compose.yaml || test -f compose.yml || test -f compose.yaml || test -f docker-bake.hcl"
 
 mechanical:
   # === DOCKERFILE/COMPOSE EXISTENCE ===


### PR DESCRIPTION
## Summary

Before this change, the docker-development checkpoints ran against every repo — reporting \`DC-01 Dockerfile must exist\` as an error even for TYPO3 extensions, libraries, skill repos, and other non-containerised projects. That's a false positive that pollutes assessment output for most of the netresearch portfolio.

## Change

Added a \`preconditions:\` section that gates the skill on the presence of at least one Docker artefact:

- \`Dockerfile\`
- \`Containerfile\`
- \`docker-compose.yml\` / \`docker-compose.yaml\`
- \`compose.yml\` / \`compose.yaml\`
- \`docker-bake.hcl\`

When none are present the skill is skipped cleanly (runner emits \`status: "skipped"\`, \`reason: "precondition failed"\`) rather than generating a cascade of false errors.

## Verification

| Project | Has Docker artefact | Runner result |
|---|---|---|
| t3x-nr-llm (TYPO3 extension) | no | skipped ✓ |
| ofelia (container image) | yes | 23 checkpoints ran |

## Test plan

- [ ] CI green
- [x] Manual: verified skip on non-Docker project, continued execution on Docker project