### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-development",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "repository": "https://github.com/netresearch/docker-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when working with ANY Docker task: writing Dockerfiles, config
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires docker, docker compose."
 metadata:
-  version: "1.7.0"
+  version: "1.7.1"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
## Release v1.7.1

Patch release. Bumps `.claude-plugin/plugin.json` and `skills/docker-development/SKILL.md` frontmatter `metadata.version` from `1.7.0` to `1.7.1`.

### Highlights since v1.7.0

- **`dind-testing-patterns` reference** is now cited at point-of-use in the skill and has a broader description for cross-skill discoverability ([#22](https://github.com/netresearch/docker-development-skill/pull/22)).
- **SKILL.md trimmed to fit the 500-word cap** — content preserved by moving detail into existing references.
- **Release pipeline hardening** — dropped the deprecated `with: bump:` block + `workflow_dispatch.bump` input so releases happen exclusively via locally-signed tags, plus SLSA-provenance permissions on the caller ([#20](https://github.com/netresearch/docker-development-skill/pull/20), [#21](https://github.com/netresearch/docker-development-skill/pull/21)).

### Release plan

After merge: tag main with a signed annotated tag, push, the `skill-repo-skill` reusable workflow publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit ... --notes-file`.
