### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-development",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "repository": "https://github.com/netresearch/docker-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when working with ANY Docker task: writing Dockerfiles, config
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires docker, docker compose."
 metadata:
-  version: "1.7.1"
+  version: "1.8.0"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release **v1.8.0** (minor bump, conventional commits since v1.7.1).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.8.0.

Changes since v1.7.1:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- 
- feat: add .pre-commit-config.yaml mirroring CI checks

After merge: a signed tag `v1.8.0` on `main` triggers the release workflow.