### PR TITLE
chore(release): v1.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-development",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "repository": "https://github.com/netresearch/docker-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,5 @@
     },
     "extra": {
         "ai-agent-skill": "skills/docker-development/SKILL.md"
-    },
-    "version": "1.2.0"
+    }
 }

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when working with ANY Docker task: writing Dockerfiles, config
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires docker, docker compose."
 metadata:
-  version: "1.8.0"
+  version: "1.8.1"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release v1.8.1 (patch).

Changes since v1.8.0:

- docs(ci-testing): GitLab CI runner gotchas — entrypoint must be a shell or overridden, restricted runner egress (bundle assets at build time), test the built image rather than the editable dev install (#26)
- chore: drop stale `version` field from composer.json (version-parity hook; git tag is the source of truth)

Version bump in `.claude-plugin/plugin.json` and `skills/docker-development/SKILL.md`.
