### PR TITLE
docs(ci-testing): add worker healthcheck patterns for reused app images

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -481,5 +481,26 @@
         "description": "Runs npm install/ci after copying only dependency files"
       }
     ]
+  },
+  {
+    "name": "worker-healthcheck-pgrep-self-match",
+    "prompt": "My compose worker service reuses the web image and I gave it this healthcheck, but it stays healthy even when the consumer process is dead:\n\nhealthcheck:\n  test: [\"CMD-SHELL\", \"pgrep -f 'messenger:consume' || exit 1\"]\n\nWhy, and how do I fix it?",
+    "assertions": [
+      {
+        "type": "content_regex",
+        "value": "\\[m\\]essenger|character class|\\[.\\]\\w+",
+        "description": "Recommends the [c]haracter-class self-match guard for pgrep -f"
+      },
+      {
+        "type": "content_regex",
+        "value": "itself|its own|own (shell|command)|self-match",
+        "description": "Explains that pgrep matches the probe shell's own command line"
+      },
+      {
+        "type": "content_regex",
+        "value": "negative|kill|dead|down.*unhealthy|unhealthy",
+        "description": "Advises verifying the negative case too (process down -> unhealthy)"
+      }
+    ]
   }
 ]

--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -151,6 +151,46 @@ services:
   run: docker rm -f test-container
 ```
 
+### Worker/Sidecar Services That Reuse an App Image
+
+A compose service that reuses the app image (e.g. a queue worker on the
+php-fpm+nginx web image) **inherits the image's baked-in `HEALTHCHECK`**.
+Three traps, in the order they typically bite in CI:
+
+1. **Inherited check probes a daemon the worker doesn't run** (nginx, php-fpm)
+   → the worker is permanently `unhealthy` and breaks
+   `docker compose up -d --wait` — and anything else gating on health.
+2. **`healthcheck: { disable: true }` is not a fix when `--wait` is used** —
+   compose fails with `container ... has no healthcheck configured`
+   (explicitly listed services without a check are un-waitable).
+   Give the worker a real check instead.
+3. **A naive `pgrep -f` check is *always* healthy** — the `CMD-SHELL`
+   wrapper's own command line contains the search string, so `pgrep`
+   matches the probe shell itself, even with a dead worker.
+
+```yaml
+services:
+  worker:
+    image: myapp:latest   # inherits the web image's HEALTHCHECK
+    command: php bin/console messenger:consume async
+    healthcheck:
+      # WRONG: matches the probe's own shell -- healthy forever
+      # test: ["CMD-SHELL", "pgrep -f 'messenger:consume' || exit 1"]
+      # RIGHT: [c]haracter-class guard prevents self-match
+      test: ["CMD-SHELL", "pgrep -f '[m]essenger:consume' || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+```
+
+Verify any health probe **both ways**: process up → `healthy` AND process
+killed → `unhealthy`. The naive `pgrep` pattern passes the positive test
+and hides the bug.
+
+Prefer letting a worker exit on its own limits (`exec` the daemon as PID 1,
+restart policy with backoff) over in-container `while true ... || true`
+loops that mask fatal errors from orchestration.
+
 ## Pattern 5: Secret Scanning with Exclusions
 
 ### Problem


### PR DESCRIPTION
## Summary

Adds a "Worker/Sidecar Services That Reuse an App Image" subsection to `references/ci-testing.md` (Pattern 4: Health Check Verification), distilled from a real incident chain on 2026-06-12 where a compose stack gained a `worker` service reusing the web image (php-fpm+nginx with a baked-in nginx HEALTHCHECK). Three successive CI failures, each verified empirically in containers:

1. **Inherited HEALTHCHECK**: the worker inherited the image's nginx health check but runs no nginx, so it was permanently `unhealthy` and `docker compose up -d --wait` failed.
2. **`healthcheck: { disable: true }`**: not a fix under `--wait` -- compose fails differently with `container ... has no healthcheck configured` (explicitly listed services without a check are un-waitable).
3. **Naive `pgrep` probe**: `test: ["CMD-SHELL", "pgrep -f 'messenger:consume' || exit 1"]` was *always* healthy, even with a dead worker -- the CMD-SHELL wrapper's own command line contains the search string, so pgrep matches the probe shell itself. The working pattern is the character-class guard: `pgrep -f '[m]essenger:consume'`. Verified both ways in containers: live consumer -> healthy, dead consumer -> unhealthy (the naive pattern stayed healthy with the consumer dead).

The new subsection also notes that any health probe must be verified in both the positive and the negative case (the naive pattern passes the positive test and hides the bug), and that workers should exit on their own limits (`exec` as PID 1 + restart policy) instead of `while true ... || true` loops that mask fatal errors from orchestration.

## Changes

- `skills/docker-development/references/ci-testing.md`: new subsection under Pattern 4 with annotated compose example
- `evals/evals.json`: new eval `worker-healthcheck-pgrep-self-match` covering the pgrep self-match trap

SKILL.md is untouched (word-cap unaffected; `references/ci-testing.md` is already listed).

## Validation

- `pre-commit run` on changed files: all hooks pass (markdownlint, check-json, whitespace/EOF)
- Pre-existing baseline: shellcheck fails on `scripts/verify-harness.sh` (info-level SC2148/SC2016), untouched by this PR
