### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-development",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "repository": "https://github.com/netresearch/docker-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when working with ANY Docker task: writing Dockerfiles, config
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires docker, docker compose."
 metadata:
-  version: "1.8.1"
+  version: "1.9.0"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Release v1.9.0.

Bumps plugin.json + skill metadata version 1.8.1 → 1.9.0.

Content since v1.8.1:
- feat: document root-owned bind-mount artifacts and their cleanup (#28)
- docs(ci-testing): worker healthcheck patterns for reused app images (#29)
- docs(docker-development): local boot-test pitfalls (#30)