### PR TITLE
Note docker-bake targets must inherit docker-metadata-action

### DIFF
--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -325,6 +325,61 @@ A non-editable install in the image (`pip install .`, `npm install <tarball>`) d
 - run: docker run --rm app:test render fixture.json /tmp/out   # real command, end-to-end
 ```
 
+## Pattern 11: Bake targets must inherit `docker-metadata-action`
+
+### Problem
+
+When a workflow migrates from `docker/build-push-action` to
+`docker/bake-action`, the tags computed by `docker/metadata-action`
+(semver from release tags, branch tags, `latest`) are **silently dropped**.
+There is no CI error — the registry only ever updates the tags hardcoded in
+`docker-bake.hcl`, so release and branch tags go stale or missing.
+
+`docker/metadata-action` writes a generated bake definition exposing a
+`docker-metadata-action` target that carries the computed `tags`/`labels`.
+A bake target only picks them up if it explicitly inherits that target.
+
+### Solution
+
+Declare a stub `docker-metadata-action` target with local defaults and have
+the real target inherit it. In CI, the metadata-action's generated bake file
+replaces the stub; locally, the defaults apply.
+
+```hcl
+# docker-bake.hcl
+target "docker-metadata-action" {
+  tags = ["myapp:dev"]   # local default; replaced by metadata-action in CI
+}
+
+target "app" {
+  inherits  = ["docker-metadata-action"]
+  platforms = ["linux/amd64", "linux/arm64"]
+  # Do NOT set `tags` here: a target's own attributes override inherited
+  # ones, so a local `tags` would discard the CI-computed tags.
+}
+```
+
+Re-add rolling tags such as `latest`/`production` through the
+metadata-action config, not the bake file:
+
+```yaml
+- uses: docker/metadata-action@v5
+  with:
+    images: ghcr.io/org/myapp
+    tags: |
+      type=raw,value=latest,enable={{is_default_branch}}
+```
+
+### Verify Both Paths
+
+```bash
+# Local: stub defaults apply
+docker buildx bake --print
+
+# CI: simulate the generated metadata file replacing the stub
+docker buildx bake -f docker-bake.hcl -f /tmp/metadata-bake.json --print
+```
+
 ## Complete CI Workflow Example
 
 ```yaml


### PR DESCRIPTION
Adds a CI testing pattern documenting a silent failure mode when migrating from `docker/build-push-action` to `docker/bake-action`: the tags computed by `docker/metadata-action` (semver, branch, `latest`) are dropped unless the bake target inherits the generated `docker-metadata-action` target.

The new Pattern 11 in `references/ci-testing.md` explains the symptom (registry only updates hardcoded `docker-bake.hcl` tags, no CI error), the stub-target fix that keeps both CI and local `docker buildx bake` working, and how to verify both paths with `--print`.

Generic, no project-specific details. Promoted from an accumulated field note.
