### PR TITLE
feat: add docker-via-wsl skill for Windows hosts using WSL2 backend

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "ci-cd"
   ],
   "skills": [
-    "./skills/docker-development"
+    "./skills/docker-development",
+    "./skills/docker-via-wsl"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,12 @@
 │   ├── checkpoints.yaml                # Evaluation checkpoints
 │   └── references/
 │       ├── ci-testing.md               # CI testing patterns for containers
-│       └── dind-testing-patterns.md    # Docker-in-Docker testing patterns
+│       ├── dind-testing-patterns.md    # Docker-in-Docker testing patterns
+│       └── bind-mount-ownership.md     # root-owned bind-mount artifacts
+├── skills/docker-via-wsl/              # Windows: run docker through WSL2
+│   ├── SKILL.md                        # Skill definition
+│   └── references/
+│       └── diagnosis-and-fix.md        # wrong-bind-mount diagnosis + fix
 ├── Build/
 │   ├── Scripts/
 │   │   └── check-plugin-version.sh     # Version validation script
@@ -45,6 +50,9 @@
 
 ## References
 
-- [SKILL.md](skills/docker-development/SKILL.md) — full skill definition
+- [docker-development SKILL.md](skills/docker-development/SKILL.md) — full skill definition
+- [docker-via-wsl SKILL.md](skills/docker-via-wsl/SKILL.md) — run docker through WSL2 on Windows hosts
 - [CI Testing](skills/docker-development/references/ci-testing.md) — CI testing patterns
 - [DinD Patterns](skills/docker-development/references/dind-testing-patterns.md) — Docker-in-Docker testing
+- [Bind-Mount Ownership](skills/docker-development/references/bind-mount-ownership.md) — root-owned bind-mount artifacts
+- [WSL Diagnosis & Fix](skills/docker-via-wsl/references/diagnosis-and-fix.md) — wrong-bind-mount diagnosis from a Windows shell

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ Agent Skill for Docker image development - Dockerfile best practices, CI testing
 - **Docker Compose** - Service orchestration, health checks, networking
 - **Docker Bake** - Multi-platform builds with BuildKit
 - **Security** - Vulnerability scanning, non-root users, secret management
+- **Windows / WSL2** - Run docker through WSL when Docker Desktop uses the WSL2 backend (separate `docker-via-wsl` skill)
+
+## Skills
+
+This package bundles two skills:
+
+- **`docker-development`** — Dockerfile, compose, bake, CI testing, and security patterns.
+- **`docker-via-wsl`** — for AI agents running on a Windows host *outside* WSL: re-issue every `docker`/`docker compose` command inside WSL (via `wsl.exe`) so Docker Desktop's WSL2 backend does not corrupt bind-mount paths.
 
 ## Automatic Triggers
 
-This skill activates automatically when working with:
+The `docker-development` skill activates automatically when working with:
 
 | File Pattern | Description |
 |--------------|-------------|
@@ -23,6 +31,8 @@ This skill activates automatically when working with:
 | `docker-compose.yml`, `compose.yml` | Multi-container orchestration |
 | `docker-bake.hcl` | BuildKit bake configurations |
 | `.dockerignore` | Build context optimization |
+
+The `docker-via-wsl` skill activates when an agent on a Windows shell (Git Bash/MSYS/PowerShell, *outside* WSL) is about to run any `docker` command.
 
 ## Installation
 
@@ -41,6 +51,7 @@ Install with any [Agent Skills](https://agentskills.io)-compatible agent:
 
 ```bash
 npx skills add https://github.com/netresearch/docker-development-skill --skill docker-development
+npx skills add https://github.com/netresearch/docker-development-skill --skill docker-via-wsl
 ```
 
 ### Download Release
@@ -104,9 +115,10 @@ docker compose config > /dev/null
 
 ## References
 
-Extended documentation in `skills/docker-development/references/`:
+Extended documentation in the skill `references/` directories:
 
-- `ci-testing.md` - Comprehensive CI testing patterns
+- `docker-development/references/ci-testing.md` - Comprehensive CI testing patterns
+- `docker-via-wsl/references/diagnosis-and-fix.md` - Diagnose and fix a wrong bind mount caused by driving Docker from a Windows shell
 
 ## Contributing
 

--- a/skills/docker-via-wsl/SKILL.md
+++ b/skills/docker-via-wsl/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: docker-via-wsl
+description: "Use when YOU (the AI agent) are running on Windows OUTSIDE WSL (Git Bash/MSYS/PowerShell shell) and need to run ANY docker / docker compose command. Docker Desktop runs on the WSL2 engine, so commands must be re-issued INSIDE WSL via wsl.exe -- running them from the Windows shell on a network/SMB drive (Z:, UNC) corrupts bind-mount paths. Does NOT apply if your shell is already inside WSL. Triggers on: docker, docker compose, docker-compose, container, bind mount, volume, 'is a directory', mount source wrong, Windows + Docker Desktop, WSL."
+license: "(MIT AND CC-BY-SA-4.0)"
+compatibility: "Windows host with Docker Desktop using the WSL2 backend."
+metadata:
+  version: "1.9.1"
+  repository: "https://github.com/netresearch/docker-development-skill"
+  author: "Netresearch DTT GmbH"
+allowed-tools:
+  - "Bash(wsl.exe:*)"
+  - "Bash(docker:*)"
+  - "Bash(uname:*)"
+  - "Read"
+  - "Glob"
+  - "Grep"
+---
+
+# Docker via WSL (Windows)
+
+## When this applies
+
+This applies when **you, the AI agent, are running on a Windows host and your
+shell is OUTSIDE WSL** -- your Bash tool is Git Bash/MSYS (`uname -s` shows
+`MINGW64…`/`MSYS…`) or you are in PowerShell/cmd. The `docker` binary there
+talks to Docker Desktop, but the daemon and its filesystem live in WSL2, so you
+must run commands inside WSL via `wsl.exe`.
+
+If your shell is **already inside WSL** (`uname -s` shows `Linux`, native path
+`/home/<user>/...`), this skill does **not** apply -- run `docker` directly.
+
+## The problem
+
+On Windows, Docker Desktop's daemon runs **inside the WSL2 VM**. Issue **every
+`docker` command** -- `run`, `build`, `exec`, `pull`, `push`,
+`volume`, `network`, `inspect`, `compose`, … -- **from inside WSL**, against a
+**native Linux path**. Never from a Windows shell (Git Bash/MSYS/PowerShell),
+especially on a mapped network/SMB drive (`Z:`, UNC `\\host\share`).
+
+## Why it matters
+
+Driving Docker from a Windows shell whose CWD is on a network share forces
+Docker Desktop to translate the Windows bind path (e.g. `Z:\proj\config`) into
+a VM path. On SMB/UNC drives this is unreliable: it can **duplicate a path
+segment** (e.g. `…/user/user/proj/config`), so Docker mounts a **wrong, empty
+directory** and **auto-creates the missing bind source as an empty directory**.
+A file the container expects (`init.sql`, a config file) then appears as a
+**directory** -> `could not read from input file: Is a directory`. Your editor
+writes still land on the *correct* path via the share, so host and container
+views silently diverge.
+
+This is NOT a Docker cache bug nor a "single-file bind mounts are fragile"
+problem (single-file binds work fine from WSL). The root cause is **piloting
+Docker from Windows/SMB instead of from WSL**.
+
+## The rule
+
+Run **any** Docker command through WSL, in a native Linux path:
+
+```bash
+wsl.exe -e bash -lc "cd /home/<user>/<project> && docker compose up -d"
+wsl.exe -e bash -lc "docker ps"
+wsl.exe -e bash -lc "docker build -t myimg /home/<user>/<project>"
+```
+
+Keep the project on the **Linux filesystem** the WSL distro sees natively
+(`/home/<user>/...`), not browsed through the Windows drive letter.
+
+## Diagnosis and fix
+
+See `references/diagnosis-and-fix.md` for inspecting the mounted path, comparing
+host vs container views, and cleaning up a phantom bind directory.

--- a/skills/docker-via-wsl/references/diagnosis-and-fix.md
+++ b/skills/docker-via-wsl/references/diagnosis-and-fix.md
@@ -1,0 +1,43 @@
+# Diagnosis and Fix: Wrong Bind Mount from a Windows Shell
+
+Use this when a container's bind mount looks wrong (a phantom directory, an
+empty mount, or `Is a directory` where a file was expected) and you suspect
+Docker was driven from a Windows shell instead of from WSL.
+
+## Diagnosis
+
+```bash
+# 1. What path did Docker actually mount? Look for a duplicated/odd segment.
+docker inspect <container> --format '{{range .Mounts}}{{.Destination}} <- {{.Source}}{{"\n"}}{{end}}'
+
+# 2. What does the container actually see vs the host?
+docker exec <container> ls -la <mount-target>     # container view
+ls -la <host-dir>                                 # host (Windows) view
+#   Divergence (host shows file X, container shows empty or a phantom dir)
+#   == path-translation mismatch -> you are driving Docker from Windows/SMB.
+
+# 3. Confirm the WSL2 backend + which distro is integrated:
+wsl.exe -l -v
+```
+
+A bind `.Source` containing `/run/desktop/mnt/host/uC/<ip>/...` (UNC-translated),
+especially with a **doubled** directory segment, is the tell-tale sign.
+
+## Fix
+
+- Re-issue the command from inside WSL against the native Linux path:
+
+  ```bash
+  wsl.exe -e bash -lc "cd /home/<user>/<project> && docker compose up -d"
+  ```
+
+- If Docker already auto-created a phantom bind directory, remove it from the
+  view that Docker uses (a throwaway container `rm -rf` on the mount, or delete
+  it on the Linux filesystem), then recreate the container from WSL:
+
+  ```bash
+  wsl.exe -e bash -lc "docker run --rm -v /home/<user>/<project>:/work alpine rm -rf /work/<phantom-dir>"
+  ```
+
+- Keep the project on the Linux filesystem the WSL distro sees natively
+  (`/home/<user>/...`), not browsed through a Windows drive letter or SMB share.


### PR DESCRIPTION
Closes #32

## What

Adds a second skill, **`docker-via-wsl`**, for AI agents running on a **Windows host outside WSL** (Git Bash/MSYS/PowerShell). Docker Desktop's daemon lives in the WSL2 VM, so every `docker`/`docker compose` command must be re-issued **inside** WSL via `wsl.exe`. Running them from a Windows shell on a network/SMB drive (`Z:`, UNC) corrupts bind-mount path translation and surfaces as the classic `could not read from input file: Is a directory`.

## Why a standalone skill (not a `docker-development` reference)

The issue proposed it as a standalone skill, and two factors confirm that form:

1. **Word budget** — `docker-development/SKILL.md` is at **498/500 words** (the repo enforces a 500-word `wc -w` ceiling). It cannot absorb a new topic + its trigger keywords without cutting the maintainer's existing core content.
2. **Triggering** — the WSL gotcha must fire on *any* docker command issued from a Windows shell (even a bare `docker ps`), which is orthogonal to "doing docker development". A dedicated skill description gives that broad, precise trigger.

The plugin already exposes a `skills` array, so multi-skill is supported at the plugin/marketplace level.

## Changes

- `skills/docker-via-wsl/SKILL.md` — when-it-applies / the problem / why it matters / the rule (frontmatter conformed to repo conventions: split license, `metadata.version` synced to `1.9.1`, scoped `allowed-tools` like the sibling skill rather than the issue's bare `Bash`).
- `skills/docker-via-wsl/references/diagnosis-and-fix.md` — inspect the mounted path, compare host vs container views, clean up a phantom bind directory.
- `.claude-plugin/plugin.json` — register the new skill in the `skills` array.
- `README.md`, `AGENTS.md` — document both skills (also fills in the already-missing `bind-mount-ownership.md` entry in the AGENTS.md tree/index).

## Verification (local)

- `validate-skill.sh` → **0 errors** (6 pre-existing README-template warnings, unchanged from `main`).
- `check-version-parity.sh` → plugin.json and both `SKILL.md` `metadata.version` match at `1.9.1`.
- Word counts: `docker-development` 498, `docker-via-wsl` 499 (≤ 500).
- `markdownlint-cli2` → 0 errors on all changed markdown.
- `scripts/verify-harness.sh` → Harness Maturity Level 3 (Enforced), complete.

No version bump in this PR — the maintainer's release flow (chore(release) commit + signed tag) bumps `plugin.json` and every `SKILL.md` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)