### PR TITLE
docs(references): GPG verification in image builds

### DIFF
--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -116,7 +116,7 @@ target "app" {
 2. **Mock upstream DNS**: `docker run --rm --add-host backend:127.0.0.1 nginx-image nginx -t`
 3. **Compose validation**: `cp .env.example .env` before `docker compose config`
 4. **Secret scanning**: Exclude `.env.example`, README, docs from scanners
-5. **Root-owned artifacts**: in-container installs leave root-owned bind-mount dirs (`EACCES` on host) -- `references/bind-mount-ownership.md`
+5. **Root-owned artifacts**: root-owned bind-mount dirs (`EACCES`) -- `references/bind-mount-ownership.md`
 
 ## .dockerignore
 
@@ -131,5 +131,6 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 ## References
 
 - `references/ci-testing.md` -- CI testing patterns for Docker images
-- `references/dind-testing-patterns.md` -- Docker-in-Docker (DinD) testing patterns
+- `references/dind-testing-patterns.md` -- Docker-in-Docker testing patterns
 - `references/bind-mount-ownership.md` -- root-owned bind-mount artifacts
+- `references/gpg-verification.md` -- gpgv patterns; stale keybox locks

--- a/skills/docker-development/references/gpg-verification.md
+++ b/skills/docker-development/references/gpg-verification.md
@@ -1,0 +1,67 @@
+# GPG Signature Verification in Image Builds
+
+Patterns for verifying downloaded release tarballs against GPG keys inside
+multi-stage builds — and the layer pitfall that breaks the naive approach.
+Distilled from NRS-4496 (central release-key image for PHP/nginx builds).
+
+## Pitfall: gpg import bakes a stale keybox lock into the layer
+
+With gnupg 2.4, `gpg --import` in one `RUN` starts keyboxd/gpg-agent and leaves
+`/root/.gnupg/public-keys.d/*.lock` behind **inside the committed layer**. The
+next `RUN` that touches the keyring (e.g. `gpg --verify`) then hangs on the
+stale lock and dies:
+
+```text
+gpg: Note: database_open ... waiting for lock (held by 9) ...
+gpg: keydb_search failed: Operation timed out
+gpg: Can't check signature: No public key
+```
+
+If you must import, clean up in the **same** `RUN` that imported:
+
+```dockerfile
+RUN gpg --no-tty --batch --import /tmp/keys.asc \
+ && gpgconf --kill all \
+ && rm -f /root/.gnupg/public-keys.d/*.lock
+```
+
+## Prefer gpgv: verify without any keyring state
+
+`gpgv` (part of gnupg, also busybox-compatible environments via the gnupg
+package) reads **binary** keyring files directly — no import, no `~/.gnupg`,
+no agent, no locks, and the accepted signer set is exactly the key files you
+pass:
+
+```dockerfile
+COPY --from=release-keys /keys/php/8.3/ /tmp/gpg-keys/
+RUN set -eux; \
+    for k in /tmp/gpg-keys/*.gpg; do \
+        [ -s "$k" ] || exit 1; \
+        set -- "$@" --keyring "$k"; \
+    done; \
+    gpgv "$@" php.tar.xz.asc php.tar.xz
+```
+
+Convert armored keys once with `gpg --dearmor` (or ship binary exports);
+`--keyring` may be repeated per key file.
+
+## Ship keys as a scratch image, not from keyservers
+
+Public keyservers (`keyserver.ubuntu.com`, `keys.openpgp.org`) time out under
+parallel CI fan-out and break scheduled builds. Keep reviewed public keys in a
+minimal image and consume them via `COPY --from`:
+
+```dockerfile
+FROM registry.example.com/support/gpg-keys:latest@sha256:<digest> AS release-keys
+```
+
+- Final stage `FROM scratch`: nothing to patch or trust beyond the key files.
+- Tag every published digest immutably (e.g. commit SHA alongside `latest`) so
+  digest pins never reference an untagged manifest.
+- Key *material* belongs to authoritative origins (e.g.
+  `php.net/distributions/php-keyring.gpg`, `nginx.org/keys/*.key`), never to a
+  keyserver fetch at build time.
+
+Reference implementation: `support/gpg-keys` on git.netresearch.de — including
+`verify-release`/`get-verified-release` helper scripts shipped *in* the image
+(POSIX sh, executed by the consumer's shell; a `scratch` image runs nothing).

--- a/skills/docker-development/references/gpg-verification.md
+++ b/skills/docker-development/references/gpg-verification.md
@@ -7,7 +7,8 @@ Distilled from NRS-4496 (central release-key image for PHP/nginx builds).
 ## Pitfall: gpg import bakes a stale keybox lock into the layer
 
 With gnupg 2.4, `gpg --import` in one `RUN` starts keyboxd/gpg-agent and leaves
-`/root/.gnupg/public-keys.d/*.lock` behind **inside the committed layer**. The
+`public-keys.d/*.lock` behind in the GnuPG home **inside the committed layer**
+(`/root/.gnupg` when building as root, else `$GNUPGHOME`/`~/.gnupg`). The
 next `RUN` that touches the keyring (e.g. `gpg --verify`) then hangs on the
 stale lock and dies:
 
@@ -22,7 +23,7 @@ If you must import, clean up in the **same** `RUN` that imported:
 ```dockerfile
 RUN gpg --no-tty --batch --import /tmp/keys.asc \
  && gpgconf --kill all \
- && rm -f /root/.gnupg/public-keys.d/*.lock
+ && rm -f "$(gpgconf --list-dirs homedir)"/public-keys.d/*.lock
 ```
 
 ## Prefer gpgv: verify without any keyring state


### PR DESCRIPTION
New reference from a retro of the NRS-4496 session (central release-key image for PHP/nginx builds):

- **Stale keybox lock pitfall:** gnupg 2.4's `gpg --import` in one `RUN` bakes `public-keys.d/*.lock` into the layer; the next `RUN`'s `gpg --verify` times out (`waiting for lock (held by 9)`). Broke a real build; fix is same-RUN `gpgconf --kill all` + lock removal.
- **Preferred pattern:** `gpgv --keyring <key>.gpg` — no import, no `~/.gnupg` state, accepted signer set is exactly the key files passed.
- **Keys-as-scratch-image pattern** replacing flaky build-time keyserver fetches, with immutable digest tagging.

SKILL.md: one reference-table line added; two existing lines trimmed to stay within the 500-word budget (now 500 words).