### PR TITLE
docs(docker-development): trim generic CI scaffolding, bump stale pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docker compose config > /dev/null
 
 Extended documentation in the skill `references/` directories:
 
-- `docker-development/references/ci-testing.md` - Comprehensive CI testing patterns
+- `docker-development/references/ci-testing.md` - Retro-born CI testing gotchas
 - `docker-via-wsl/references/diagnosis-and-fix.md` - Diagnose and fix a wrong bind mount caused by driving Docker from a Windows shell
 
 ## Contributing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Main entry point loaded by agent frameworks. Contains:
 
 ### Reference Docs (`skills/docker-development/references/`)
 
-- **ci-testing.md** — comprehensive CI testing patterns for container images
+- **ci-testing.md** — retro-born CI testing gotchas for container images
 - **dind-testing-patterns.md** — Docker-in-Docker testing strategies
 
 ### Checkpoints (`skills/docker-development/checkpoints.yaml`)

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -32,13 +32,13 @@ Patterns for building, testing, and deploying Docker containers.
 ### Multi-Stage Build (Node.js)
 
 ```dockerfile
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --only=production
 COPY . .
 
-FROM node:20-alpine
+FROM node:24-alpine
 RUN addgroup -g 1001 app && adduser -u 1001 -G app -D app
 USER app
 COPY --from=builder /app .
@@ -50,7 +50,7 @@ CMD ["node", "server.js"]
 ### Multi-Stage Build (Go -- scratch/distroless)
 
 ```dockerfile
-FROM golang:1.22-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY go.* ./
 RUN go mod download

--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -1,157 +1,10 @@
 # CI Testing Patterns for Docker Images
 
-Comprehensive patterns for testing Docker images in CI/CD pipelines.
+Deeper CI/CD gotchas beyond the basics. For entrypoint bypass, DNS mocking,
+compose validation, and secret-scan exclusions, see SKILL.md's Quick
+Reference § CI Testing Gotchas.
 
-## The Challenge
-
-Docker images often have:
-- **Entrypoint scripts** that run before any command
-- **Service dependencies** (databases, caches) that don't exist in CI
-- **Network configurations** referencing other containers
-- **Required environment variables** that fail validation
-
-These cause CI failures that don't occur in local development.
-
-## Pattern 1: Entrypoint Bypass
-
-### Problem
-
-```dockerfile
-# Dockerfile
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["php-fpm"]
-```
-
-```yaml
-# CI - FAILS
-- run: docker run --rm myimage php -v
-# Output: entrypoint.sh runs, starts services, php -v never executes properly
-```
-
-### Solution
-
-```yaml
-# Override entrypoint for direct command execution
-- run: docker run --rm --entrypoint php myimage -v
-- run: docker run --rm --entrypoint php myimage -m  # List modules
-- run: docker run --rm --entrypoint node myimage --version
-- run: docker run --rm --entrypoint /bin/sh myimage -c "cat /etc/os-release"
-```
-
-### When to Use
-
-- Verifying installed software versions
-- Checking available extensions/modules
-- Testing configuration files
-- Running diagnostic commands
-
-## Pattern 2: DNS Mocking for Upstream Services
-
-### Problem
-
-```nginx
-# nginx.conf
-upstream backend {
-    server app:9000;
-}
-```
-
-```yaml
-# CI - FAILS
-- run: docker run --rm nginx-image nginx -t
-# Error: host not found in upstream "app:9000"
-```
-
-### Solution
-
-```yaml
-# Provide fake DNS resolution for upstream hosts
-- run: |
-    docker run --rm \
-      --add-host app:127.0.0.1 \
-      --add-host database:127.0.0.1 \
-      --add-host cache:127.0.0.1 \
-      nginx-image nginx -t
-```
-
-### Multiple Upstreams
-
-```yaml
-- name: Test nginx config
-  run: |
-    docker run --rm \
-      --add-host php-fpm:127.0.0.1 \
-      --add-host mailpit:127.0.0.1 \
-      --add-host redis:127.0.0.1 \
-      myapp-nginx nginx -t
-```
-
-## Pattern 3: Docker Compose Validation
-
-### Problem
-
-```yaml
-# compose.yml
-services:
-  app:
-    environment:
-      - DB_PASSWORD=${DB_PASSWORD:?Required}
-```
-
-```yaml
-# CI - FAILS
-- run: docker compose config
-# Error: required variable DB_PASSWORD is missing
-```
-
-### Solution
-
-```yaml
-- name: Create test environment
-  run: |
-    cp .env.example .env
-    # Replace all CHANGE_ME placeholders
-    sed -i 's/CHANGE_ME_[A-Z_]*/test_password/g' .env
-
-- name: Validate compose syntax
-  run: docker compose config > /dev/null
-```
-
-### Alternative: Inline Variables
-
-```yaml
-- name: Validate compose
-  env:
-    DB_PASSWORD: test
-    REDIS_PASSWORD: test
-  run: docker compose config > /dev/null
-```
-
-## Pattern 4: Health Check Verification
-
-### Test Health Check Command
-
-```yaml
-- name: Build image
-  run: docker build -t myapp:test .
-
-- name: Test health check
-  run: |
-    # Start container
-    docker run -d --name test-container myapp:test
-
-    # Wait for health
-    timeout 60 bash -c 'until docker inspect test-container --format="{{.State.Health.Status}}" | grep -q healthy; do sleep 2; done'
-
-    # Verify
-    docker inspect test-container --format="{{.State.Health.Status}}"
-
-- name: Cleanup
-  if: always()
-  run: docker rm -f test-container
-```
-
-### Worker/Sidecar Services That Reuse an App Image
+## Pattern 1: Worker/Sidecar Services That Reuse an App Image
 
 A compose service that reuses the app image (e.g. a queue worker on the
 php-fpm+nginx web image) **inherits the image's baked-in `HEALTHCHECK`**.
@@ -191,93 +44,9 @@ Prefer letting a worker exit on its own limits (`exec` the daemon as PID 1,
 restart policy with backoff) over in-container `while true ... || true`
 loops that mask fatal errors from orchestration.
 
-## Pattern 5: Secret Scanning with Exclusions
+## Pattern 2: GitLab CI — image entrypoint must be a shell (or be overridden)
 
-### Problem
-
-Documentation references placeholder passwords:
-
-```markdown
-<!-- README.md -->
-Set `DB_PASSWORD=CHANGE_ME` in your .env file
-```
-
-```yaml
-# CI - FALSE POSITIVE
-- run: git ls-files | xargs grep -l "CHANGE_ME" && exit 1
-# Fails on README.md, QUICKSTART.md, etc.
-```
-
-### Solution
-
-```yaml
-- name: Check for leaked secrets
-  run: |
-    # Files that legitimately reference placeholders
-    EXCLUDE_PATTERN=".env.example|README|QUICKSTART|docs/|Makefile|\.github/"
-
-    # Find files with secrets, excluding legitimate references
-    FOUND=$(git ls-files | xargs grep -l "CHANGE_ME" | grep -vE "$EXCLUDE_PATTERN" || true)
-
-    if [ -n "$FOUND" ]; then
-      echo "Found secrets in:"
-      echo "$FOUND"
-      exit 1
-    fi
-    echo "No leaked secrets detected"
-```
-
-## Pattern 6: Multi-Platform Build Testing
-
-```yaml
-- name: Set up QEMU
-  uses: docker/setup-qemu-action@v3
-
-- name: Set up Buildx
-  uses: docker/setup-buildx-action@v3
-
-- name: Build multi-platform
-  uses: docker/build-push-action@v6
-  with:
-    platforms: linux/amd64,linux/arm64
-    load: false  # Can't load multi-platform
-    cache-from: type=gha
-    cache-to: type=gha,mode=max
-```
-
-## Pattern 7: Integration Testing with Service Containers
-
-```yaml
-jobs:
-  test:
-    services:
-      database:
-        image: mariadb:11
-        env:
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: testdb
-        options: >-
-          --health-cmd="healthcheck.sh --connect --innodb_initialized"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
-    steps:
-      - name: Build app image
-        run: docker build -t myapp:test .
-
-      - name: Run integration tests
-        run: |
-          docker run --rm \
-            --network ${{ job.container.network }} \
-            -e DB_HOST=database \
-            -e DB_PASSWORD=test \
-            myapp:test npm test
-```
-
-## Pattern 8: GitLab CI — image entrypoint must be a shell (or be overridden)
-
-Unlike a test-time `--entrypoint` bypass (Pattern 1), GitLab **runs every job's `script:` via `sh -c`**. If the image used as a job `image:` has a non-shell `ENTRYPOINT ["mytool"]`, the runner effectively runs `mytool sh -c '…'` → **`No such command 'sh'`**, and the job fails before the script runs.
+Unlike a test-time `--entrypoint` bypass, GitLab **runs every job's `script:` via `sh -c`**. If the image used as a job `image:` has a non-shell `ENTRYPOINT ["mytool"]`, the runner effectively runs `mytool sh -c '…'` → **`No such command 'sh'`**, and the job fails before the script runs.
 
 ```yaml
 job:
@@ -290,7 +59,7 @@ job:
 
 A CLI image also meant for `docker run mytool …` can keep `ENTRYPOINT ["mytool"]`, but **document** that GitLab consumers must set `entrypoint: [""]`. If the image is *primarily* a CI image, prefer no tool entrypoint (use `CMD`).
 
-## Pattern 9: Restricted runner egress — bundle external assets at build time
+## Pattern 3: Restricted runner egress — bundle external assets at build time
 
 CI runners (especially internal/self-hosted) often have **no outbound internet**. An image that fetches something at *runtime* (`page.add_script_tag(url="https://cdn…/axe.min.js")`, `curl https://…` in the entrypoint, a remote `pip`/`npm` install) works locally but fails in CI.
 
@@ -312,7 +81,7 @@ ENV AXE_PATH=/opt/axe-core/axe.min.js
 
 …and have the app prefer the local file (CDN as a dev-only fallback).
 
-## Pattern 10: Test the *built image*, not just the editable dev install
+## Pattern 4: Test the *built image*, not just the editable dev install
 
 A non-editable install in the image (`pip install .`, `npm install <tarball>`) does not behave like the editable/dev checkout your tests ran against. Classic failure: **data files resolved by walking from `__file__`** (`Path(__file__).resolve().parents[2]/"data"/…`) don't exist under `site-packages`, so the tool can't find its catalog/config inside the container even though `pytest` was green.
 
@@ -325,7 +94,7 @@ A non-editable install in the image (`pip install .`, `npm install <tarball>`) d
 - run: docker run --rm app:test render fixture.json /tmp/out   # real command, end-to-end
 ```
 
-## Pattern 11: Bake targets must inherit `docker-metadata-action`
+## Pattern 5: Bake targets must inherit `docker-metadata-action`
 
 ### Problem
 
@@ -378,62 +147,6 @@ docker buildx bake --print
 
 # CI: simulate the generated metadata file replacing the stub
 docker buildx bake -f docker-bake.hcl -f /tmp/metadata-bake.json --print
-```
-
-## Complete CI Workflow Example
-
-```yaml
-name: Docker CI
-
-on: [push, pull_request]
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup test environment
-        run: |
-          cp .env.example .env
-          sed -i 's/CHANGE_ME_[A-Z_]*/ci_test_value/g' .env
-
-      - name: Validate compose
-        run: docker compose config > /dev/null
-
-  build-and-test:
-    runs-on: ubuntu-latest
-    needs: validate
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Build images
-        run: docker compose build
-
-      - name: Test PHP version
-        run: docker run --rm --entrypoint php myapp:latest -v | grep "8.4"
-
-      - name: Test nginx config
-        run: docker run --rm --add-host app:127.0.0.1 myapp-nginx nginx -t
-
-      - name: Start stack
-        run: |
-          cp .env.example .env
-          sed -i 's/CHANGE_ME_[A-Z_]*/ci_test/g' .env
-          docker compose up -d
-
-      - name: Wait for healthy
-        run: |
-          timeout 120 bash -c 'until docker compose ps | grep -q healthy; do sleep 5; done'
-
-      - name: Test endpoint
-        run: curl -f http://localhost/ || exit 1
-
-      - name: Cleanup
-        if: always()
-        run: docker compose down -v
 ```
 
 ## Local boot-test pitfalls


### PR DESCRIPTION
Part of netresearch/skill-repo-skill#157. Ticks the `docker-development-skill` checkbox.

Rubric: `netresearch/skill-repo-skill` `skills/skill-repo/references/skill-quality.md` § "Body rules" / "When to split to `references/`" — content a one-line prompt regenerates (generic tutorials, restated public best practice, boilerplate) is a cut target; retro-born failure patterns, version/ecosystem facts, and inference-suppression rules are hard-protected.

## Re-verification against current tree

Both audit-named targets still existed at `origin/main` (950264d) before this change:

- `skills/docker-development/SKILL.md` Quick Reference pinned `node:20-alpine` and `golang:1.22-alpine`.
- `skills/docker-development/references/ci-testing.md` (446 lines / 1897 words) carried multiple Problem/Solution tutorial sections restating public Docker/GH-Actions knowledge already summarized as one-liners in SKILL.md's own "CI Testing Gotchas" list.

## What was cut (ci-testing.md, rubric test: one-line-prompt-regenerable)

- Pattern 1 Entrypoint Bypass, Pattern 2 DNS Mocking, Pattern 3 Compose Validation, Pattern 5 Secret Scanning — each is a generic tutorial already condensed to one line in SKILL.md § CI Testing Gotchas (items 1-4); the reference-file elaboration added no gotcha beyond restating the technique.
- Pattern 4's "Test Health Check Command" subsection — generic build/start/wait-loop/cleanup GH Actions boilerplate, no specific failure narrative.
- Pattern 6 Multi-Platform Build Testing, Pattern 7 Integration Testing with Service Containers — standard `docker/setup-qemu-action` / `services:` copy-paste boilerplate, no incident behind it.
- "Complete CI Workflow Example" (~55 lines) — restated patterns 1-3 verbatim as a full pipeline; nothing unique.

Net: 446 → 159 lines, 1897 → 1112 words (-785 words, -41%).

## What was kept (retro-born, hard-protected)

- Worker/Sidecar HEALTHCHECK inheritance incl. the `pgrep [m]essenger:consume` self-match trap (renumbered Pattern 1; commit `bbe9274`).
- GitLab CI "image entrypoint must be a shell" `sh -c` gotcha (Pattern 2; commit `4b7e314`).
- Restricted runner egress / build-time asset bundling (Pattern 3; commit `4b7e314`).
- Built-image vs editable-install testing, `__file__`-relative data-path failure (Pattern 4; commit `4b7e314`).
- Bake target `docker-metadata-action` inheritance (Pattern 5; commit `6979edf`).
- "Local boot-test pitfalls" (port collision, foreground-log-to-file, distroless-no-shell, real-vs-benign log signals; commit `b3aa6f7`) — untouched.
- Patterns were renumbered 1-5 for a contiguous sequence (no external anchors/links referenced the old numbering — verified by repo-wide grep).

`docker-via-wsl` skill content untouched — no changes needed there.

## Stale pins (SKILL.md Quick Reference)

Verified via `mcp__package-version__check_docker_tags`:

- `node:20-alpine` → `node:24-alpine` — Node 24 ("Krypton") is the current Active LTS (Docker Hub `lts`/`lts-krypton` tags resolve to 24.18.0); Node 26 is `current` only, not yet LTS.
- `golang:1.22-alpine` → `golang:1.26-alpine` — 1.26.5 is latest stable; 1.27 is still RC (`1.27rc2`/`1.27-rc` tags only).

This is a version bump, not a content cut — the illustrative Dockerfile examples stay.

## Kept, borderline

None — every remaining section in `ci-testing.md` traces to a specific commit documenting a real incident/gotcha (verified via `git log --oneline -- skills/docker-development/references/ci-testing.md`), so no borderline calls were needed.

## Verification

```
$ wc -w skills/docker-development/SKILL.md
500 skills/docker-development/SKILL.md   # exactly at the repo's 500-word hard cap, unchanged

$ bash skill-repo-skill/skills/skill-repo/scripts/validate-skill.sh .
OK: SKILL.md is 500 words (under 500 limit)
Errors: 0
Warnings: 6   # pre-existing README-template warnings, unrelated to this change

$ skill-repo-skill/scripts/audit-skills.sh .
SKILL: docker-development — BODY: 430 words, 119 lines [PASS] — REFERENCES: 4 total -> 4/P1 reachable, 0 ORPHAN
SKILL: docker-via-wsl      — BODY: 370 words, 55 lines [PASS]  — REFERENCES: 1 total -> 1/P1 reachable, 0 ORPHAN
SUMMARY: 2 skills, 0 FAIL, 2 WARN, 0 INFO, 0 ORPHAN refs

$ pre-commit run --files skills/docker-development/SKILL.md skills/docker-development/references/ci-testing.md
trim trailing whitespace .... Passed
fix end of files ............ Passed
Validate skill repo structure Passed
Plugin/SKILL/composer version parity Passed
markdownlint-cli2 ............ Passed
(yaml/actionlint/ruff/shellcheck: no matching files, skipped)

$ grep -rn "node:20\|golang:1\.22" .   # repo-wide
none

$ grep -rn "ci-testing.md" . --include="*.md"   # reference table + AGENTS.md + README.md + docs/ARCHITECTURE.md
all still resolve — file trimmed in place, not deleted, no dangling refs
```

DO NOT MERGE.
