### PR TITLE
feat(evals): add missing docker-via-wsl eval

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -514,7 +514,7 @@
       },
       {
         "type": "content_regex",
-        "value": "-e bash -lc|bash -lc",
+        "value": "-e bash -lc",
         "description": "Uses the specific 'wsl.exe -e bash -lc' re-issue form, not a bare 'wsl' invocation"
       },
       {

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -502,5 +502,26 @@
         "description": "Advises verifying the negative case too (process down -> unhealthy)"
       }
     ]
+  },
+  {
+    "name": "docker-via-wsl-reissue-not-windows-shell",
+    "prompt": "My Bash tool's `uname -s` shows MINGW64_NT -- I'm on Windows outside WSL. The user's `docker compose up` from this Git Bash shell, run from a Z:\\ mapped network drive, fails with 'could not read from input file: Is a directory' for a bind-mounted config file. What do I do?",
+    "assertions": [
+      {
+        "type": "content_regex",
+        "value": "wsl\\.exe",
+        "description": "Re-issues the Docker command through wsl.exe instead of continuing to drive Docker from the Windows/Git-Bash shell"
+      },
+      {
+        "type": "content_regex",
+        "value": "-e bash -lc|bash -lc",
+        "description": "Uses the specific 'wsl.exe -e bash -lc' re-issue form, not a bare 'wsl' invocation"
+      },
+      {
+        "type": "content_regex",
+        "value": "SMB|network (share|drive)|Z:|UNC|WSL2",
+        "description": "Identifies the SMB/network-drive path translation inside Docker Desktop's WSL2 backend as the root cause, not a Docker cache or single-file-bind-mount bug"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Part of https://github.com/netresearch/skill-repo-skill/issues/148 (A6: eval backfill).

## Summary

The 24 existing evals in `evals/evals.json` cover the `docker-development` skill only; `docker-via-wsl` (added in a later PR) had none. Adds one eval, `docker-via-wsl-reissue-not-windows-shell`.

## Delta-discriminating assertion

Asserts the skill's core correction for an agent whose Bash shell is Git Bash/MSYS on Windows outside WSL: re-issue the failing Docker command through `wsl.exe -e bash -lc` from inside WSL2's native filesystem, instead of continuing to drive Docker from the Windows shell on a mapped network drive (the actual root cause of the "Is a directory" bind-mount failure, per `skills/docker-via-wsl/SKILL.md`). A generic baseline diagnoses this as a Docker cache bug or a fragile single-file-bind-mount problem and has no way to know the `wsl.exe -e bash -lc` re-issue pattern without having read this skill.

## Validation

```
$ bash scripts/validate-evals.sh evals/evals.json
...
Results: 53 passed, 0 failed, 0 warnings
```