### PR TITLE
docs: cache code-independent Docker tooling off the code-copy lineage

### DIFF
--- a/skills/docker-development/references/multi-stage-caching.md
+++ b/skills/docker-development/references/multi-stage-caching.md
@@ -1,0 +1,22 @@
+# Multi-stage caching: keep code-independent installs off the code-copy lineage
+
+**Symptom:** a dev/CI image rebuilds heavy tooling (apt, pecl/xdebug, browser installs, `npm ci`) on **every** source change, even though none of it depends on the code.
+
+**Cause:** the tooling stage is `FROM <the code stage>`, and the code stage ends with `COPY . .`. Docker invalidates every layer downstream of that copy on any tracked-file content change — so the tooling, layered on top, re-runs each time.
+
+**Fix — re-parent, don't reorder.** Put the code-independent installs in a *sibling* stage `FROM base` (a stage with **no** code copy), then pull the built tree into the leaf via one `COPY --from=<code-stage>`:
+
+```dockerfile
+FROM base AS deps        # composer/npm install + COPY . . + build  (code-dependent)
+FROM base AS devtools    # apt, xdebug, symfony-cli, npm ci, chromium — NO code copy
+FROM devtools AS dev
+COPY --from=deps --chown=app:app /app /app   # the ONE code-dependent layer of dev
+```
+
+A source-only edit now invalidates `deps` (and dev's copy) but leaves the whole `devtools` lineage CACHED.
+
+## Guardrails
+
+- **Isolation by lineage:** keep xdebug/chromium in the `devtools → dev → e2e` branch only. A `production`/`profiling`/`tools` stage that is `FROM base`/`FROM deps` must not inherit `devtools`, or it gains xdebug (skews profiling timings) and browser bloat. Verify with the actual `FROM` chain, not by hoping.
+- **Same-layer cleanup:** a transient `node_modules` needed only to run `npx playwright install` should be `rm -rf`'d in the *same* `RUN` (the leaf's `COPY --from=deps` overwrites it anyway) so it never bloats the layer. The browser binary lives in `~/.cache/ms-playwright`, outside `node_modules`, so it survives.
+- **Verify the cache, not just the build:** `docker build --check` + a cold build prove it *builds*; only a **content** change to a source file + rebuild proves the *caching* — BuildKit hashes content, not mtime, so a bare `touch` won't invalidate. Look for `CACHED` on the tooling layers.

--- a/skills/docker-development/references/multi-stage-caching.md
+++ b/skills/docker-development/references/multi-stage-caching.md
@@ -7,10 +7,13 @@
 **Fix — re-parent, don't reorder.** Put the code-independent installs in a *sibling* stage `FROM base` (a stage with **no** code copy), then pull the built tree into the leaf via one `COPY --from=<code-stage>`:
 
 ```dockerfile
-FROM base AS deps        # composer/npm install + COPY . . + build  (code-dependent)
-FROM base AS devtools    # apt, xdebug, symfony-cli, npm ci, chromium — NO code copy
+# composer/npm install + COPY . . + build (code-dependent)
+FROM base AS deps
+# apt, xdebug, symfony-cli, npm ci, chromium — NO code copy
+FROM base AS devtools
 FROM devtools AS dev
-COPY --from=deps --chown=app:app /app /app   # the ONE code-dependent layer of dev
+# the ONE code-dependent layer of dev
+COPY --from=deps --chown=app:app /app /app
 ```
 
 A source-only edit now invalidates `deps` (and dev's copy) but leaves the whole `devtools` lineage CACHED.


### PR DESCRIPTION
New reference `multi-stage-caching.md`. When dev/CI tooling (apt, xdebug, chromium, `npm ci`) is layered `FROM` the code stage, every source change re-runs it because `COPY . .` invalidates all downstream layers. Fix: re-parent the tooling into a sibling stage `FROM base` and pull the built tree via one `COPY --from=deps`. Includes lineage isolation (keep xdebug/chromium out of prod/profiling), same-`RUN` node_modules cleanup, and verifying the cache via a *content* change (BuildKit hashes content, not mtime).

Note: not added to SKILL.md's References index because that file is at its 500-word cap (adding a line failed Skill Validation). Suggest indexing it there when word budget allows.