### PR TITLE
fix(secrets): ARG leaks into SLSA provenance; document php-fpm worker starvation

### DIFF
--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -84,7 +84,7 @@ Manifests before source keeps install layers cached.
 RUN --mount=type=secret,id=ssh_key,dst=/root/.ssh/id_rsa git clone git@github.com:org/repo.git
 ```
 
-`ARG` leaks via `docker history` **and** the pushed image's SLSA provenance --
+`ARG` leaks via `docker history` **and** SLSA provenance --
 `references/build-secret-leaks.md`
 
 ### Docker Bake (Multi-Platform)
@@ -115,7 +115,7 @@ target "app" {
 2. **Mock upstream DNS**: `docker run --rm --add-host backend:127.0.0.1 nginx-image nginx -t`
 3. **Compose validation**: `cp .env.example .env` before `docker compose config`
 4. **Secret scanning**: exclude `.env.example`, README, docs
-5. **Root-owned artifacts**: root-owned bind-mount dirs (`EACCES`) -- `references/bind-mount-ownership.md`
+5. **Root-owned artifacts**: bind-mount dirs (`EACCES`) -- `references/bind-mount-ownership.md`
 
 ## .dockerignore
 
@@ -134,5 +134,5 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 - `references/bind-mount-ownership.md` -- root-owned bind-mount artifacts
 - `references/gpg-verification.md` -- gpgv patterns; stale keybox locks
 - `references/registry-catalogue-and-pin-rot.md` -- catalogue probes; pin rot
-- `references/build-secret-leaks.md` -- `ARG` lands in SLSA provenance
-- `references/php-fpm-worker-starvation.md` -- FastCGI keepalive pins workers
+- `references/build-secret-leaks.md` -- `ARG` in provenance
+- `references/php-fpm-worker-starvation.md` -- keepalive pins php-fpm

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -22,8 +22,8 @@ allowed-tools:
 
 1. **Minimal** -- Alpine/distroless, multi-stage
 2. **Secure** -- Non-root USER, no layer secrets, pin versions
-3. **Testable** -- CI-verifiable: entrypoint bypass, DNS mocking
-4. **Cache-efficient** -- deps first, clean in same layer
+3. **Testable** -- entrypoint bypass, DNS mocking
+4. **Cache-efficient** -- deps first, clean in-layer
 
 ## Quick Reference
 
@@ -76,7 +76,7 @@ RUN npm ci
 COPY . .
 ```
 
-Manifests before source keeps install layers cached on source-only changes.
+Manifests before source keeps install layers cached.
 
 ### BuildKit Secrets
 
@@ -84,7 +84,8 @@ Manifests before source keeps install layers cached on source-only changes.
 RUN --mount=type=secret,id=ssh_key,dst=/root/.ssh/id_rsa git clone git@github.com:org/repo.git
 ```
 
-`ENV`/`ARG`/`COPY` secrets persist in `docker history`. Use `--mount=type=secret`.
+`ARG` leaks via `docker history` **and** the pushed image's SLSA provenance --
+`references/build-secret-leaks.md`
 
 ### Docker Bake (Multi-Platform)
 
@@ -113,7 +114,7 @@ target "app" {
 1. **Bypass entrypoint**: `docker run --rm --entrypoint php myimage -v`
 2. **Mock upstream DNS**: `docker run --rm --add-host backend:127.0.0.1 nginx-image nginx -t`
 3. **Compose validation**: `cp .env.example .env` before `docker compose config`
-4. **Secret scanning**: Exclude `.env.example`, README, docs from scanners
+4. **Secret scanning**: exclude `.env.example`, README, docs
 5. **Root-owned artifacts**: root-owned bind-mount dirs (`EACCES`) -- `references/bind-mount-ownership.md`
 
 ## .dockerignore
@@ -123,8 +124,8 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 ## Compose Essentials
 
 - startup ordering: `depends_on.condition: service_healthy` + `healthcheck` `start_period`
-- `networks.internal: true` isolates databases from external access
-- `profiles: [debug]`: services start only with `--profile debug`
+- `networks.internal: true` isolates databases
+- `profiles: [debug]`: start only with `--profile debug`
 
 ## References
 
@@ -133,3 +134,4 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 - `references/bind-mount-ownership.md` -- root-owned bind-mount artifacts
 - `references/gpg-verification.md` -- gpgv patterns; stale keybox locks
 - `references/registry-catalogue-and-pin-rot.md` -- catalogue probes; pin rot
+- `references/build-secret-leaks.md` -- `ARG` lands in SLSA provenance

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -135,3 +135,4 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 - `references/gpg-verification.md` -- gpgv patterns; stale keybox locks
 - `references/registry-catalogue-and-pin-rot.md` -- catalogue probes; pin rot
 - `references/build-secret-leaks.md` -- `ARG` lands in SLSA provenance
+- `references/php-fpm-worker-starvation.md` -- FastCGI keepalive pins workers

--- a/skills/docker-development/references/build-secret-leaks.md
+++ b/skills/docker-development/references/build-secret-leaks.md
@@ -1,0 +1,63 @@
+# Where a build credential actually leaks
+
+`docker history` is the check everyone runs, and for a multi-stage build it is
+the wrong one. A credential passed as `ARG` into a builder stage never reaches
+the shipped layers — that stage is not in the final image — so the history is
+clean while the credential is public anyway.
+
+buildx attaches an SLSA provenance attestation to every pushed image and records
+the build arguments in it **verbatim**:
+
+```bash
+docker buildx imagetools inspect <ref> --format '{{json .Provenance}}' \
+  | jq -r '.[].SLSA.buildDefinition.externalParameters.request.args | keys[]'
+# build-arg:COMPOSER_AUTH   <- the value sits right there, in cleartext
+```
+
+Measured case (2026-08-12): a public GHCR package carried a working GitLab
+`glpat-` token in the attestation of **1461** published versions. The `ARG` was
+in a `composer-builder` stage that is never shipped.
+
+## Verify it, with a check that can fail
+
+Grep for the **credential pattern**, never for the argument name. The
+attestation embeds the push's commit messages and the `RUN` command lines, so
+the name matches your own commit text and reports a leak that is not there —
+that false positive cost a round of "still broken" in the session that found
+this.
+
+```bash
+for ref in "$OLD_TAG" "$NEW_TAG"; do
+  n=$(docker buildx imagetools inspect "$ref" --format '{{json .Provenance}}' \
+      | grep -oE 'glpat-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9]{20,}' | sort -u | wc -l)
+  echo "$ref: $n credential values"
+done
+```
+
+A pre-fix tag returning `1` and a post-fix tag returning `0` is the proof. A
+single post-fix `0` on its own proves nothing about the check.
+
+## The fix
+
+```dockerfile
+RUN --mount=type=secret,id=composer_auth \
+    COMPOSER_AUTH="$(cat /run/secrets/composer_auth 2>/dev/null || true)" \
+    composer install --no-dev
+```
+
+```hcl
+target "app" {
+  secret = ["type=env,id=composer_auth,env=COMPOSER_AUTH"]
+}
+```
+
+`type=env` reads the variable the CI already exports, so the calling workflow
+usually needs no change at all. Tolerate a missing secret (`|| true`): forks and
+local builds have no credential and should still resolve public dependencies
+rather than fail.
+
+## After a leak
+
+Rotation is the only remedy that acts on what is already published — the
+attestations of existing versions keep their copy of the value forever, or until
+someone deletes those package versions. Rotate first, fix the build second.

--- a/skills/docker-development/references/php-fpm-worker-starvation.md
+++ b/skills/docker-development/references/php-fpm-worker-starvation.md
@@ -1,0 +1,59 @@
+# nginx FastCGI keepalive starves php-fpm
+
+A php-fpm child stays bound to its FastCGI connection for as long as that
+connection lives. An nginx keepalive pool to php-fpm therefore does not park
+idle sockets — it parks **workers**. Size the pool at or above
+`pm.max_children` and it can pin every child, leaving arriving requests to wait
+for one to come free.
+
+```nginx
+upstream php-fpm {
+    server 127.0.0.1:9000;
+    keepalive 16;          # against pm.max_children = 10
+}
+location ~ \.php$ {
+    fastcgi_keep_conn on;  # <- makes the pool real
+}
+```
+
+## The signature — all of it at once, or it is something else
+
+- container at **0 % CPU**, memory flat — nothing is working
+- php-fpm **slowlog empty** at a low threshold
+  (`request_slowlog_timeout = 5s`): the scripts were never slow, they never got
+  a worker
+- the stalled requests answer **HTTP 200 after ~60 s**, with TTFB equal to the
+  total, and the edge proxy's access log reports the same duration, so the wait
+  is behind it
+- the very same URLs replayed **one at a time** in the same session take
+  ~100 ms
+
+The empty slowlog is the decisive one: it separates "slow code" from "never
+scheduled", and it is the measurement most likely to be skipped.
+
+## Why it hides from local testing
+
+Only a client that can issue everything at once builds the queue. Over HTTP/2
+through a reverse proxy the page's requests share one connection and arrive
+together; a direct HTTP/1.1 client opens at most six connections per origin and
+never triggers it. Reproduce **with the proxy in the path** — a stack tested by
+addressing the application container directly measures a load shape that
+production never sees.
+
+## Measured
+
+TYPO3 backend behind Caddy, `pm.max_children = 10`, opening the backend shell:
+
+| nginx | slowest request | over 5 s |
+|---|---|---|
+| `keepalive 16` + `fastcgi_keep_conn on` | 61005 ms | 5–8 of 24 |
+| `keepalive 8` + `fastcgi_keep_conn on` | 19614 ms | 1 of 24 |
+| no pool, `fastcgi_keep_conn off` | **107 ms** | none |
+
+The intermediate value still costs 19.6 s, so this is not a tuning question:
+remove the pool. `fastcgi_keep_conn off` is the nginx default, and connection
+setup to `127.0.0.1` is not worth holding a worker for.
+
+Raising `pm.max_children` instead trades memory for the same failure one load
+step further out — and where the container has a memory cap, the headroom for
+`keepalive`-many concurrently pinned children is not there to give.


### PR DESCRIPTION
Two findings from a session that lost a working credential to the internet and spent two rounds measuring the wrong thing. Both are the kind of trap where every obvious instrument reports "fine".

## `ARG` leaks into the provenance, and `docker history` cannot see it

The skill said:

> `ENV`/`ARG`/`COPY` secrets persist in `docker history`. Use `--mount=type=secret`.

For a multi-stage build the first sentence is false in the way that matters. A credential passed into a builder stage never reaches the shipped layers, so `docker history` is clean — while the value is public anyway, because buildx records every build argument **verbatim** in the SLSA provenance attestation attached to the pushed image. Anyone following the old line runs the one check that structurally cannot see the leak.

Found the hard way: a public GHCR package carried a live GitLab `glpat-` token in the attestation of **1461** published versions. `docker history` on it returns nothing.

`references/build-secret-leaks.md` adds the inspect command, the secret-mount fix for both Dockerfile and bake, and the verification trap — grep for the credential *pattern*, never the argument name, because the attestation embeds the push's commit messages and `RUN` command lines, so the name matches your own commit text and reports a leak that is not there. Verify against a pre-fix and a post-fix tag: `1` then `0`. A lone `0` proves nothing about the check.

## FastCGI keepalive parks php-fpm workers, not sockets

A php-fpm child stays bound to its FastCGI connection for its lifetime, so an nginx keepalive pool sized at or above `pm.max_children` can pin every child while requests queue behind them.

The diagnosis is expensive because the readings look healthy: 0 % CPU, flat memory, an **empty** php-fpm slowlog at a 5 s threshold — the scripts were never slow, they never got a worker — and HTTP 200 after a minute. `references/php-fpm-worker-starvation.md` states the whole signature, since each reading alone points elsewhere, and notes that it only appears over HTTP/2 through a proxy: a direct HTTP/1.1 client opens six connections per origin and never builds the queue, which is why a stack tested by addressing the app container directly measures a load shape production never sees.

Measured on a TYPO3 backend behind Caddy, `pm.max_children = 10`: `keepalive 16` → 61005 ms slowest request, `keepalive 8` → 19614 ms, no pool → **107 ms**.

## Word budget

`SKILL.md` was at exactly the 500-word cap, so the added line and the two reference rows are paid for by tightening prose that the adjacent code blocks already state. Validator: 500 words, 0 errors.
