### PR TITLE
chore(release): v1.13.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-development",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "repository": "https://github.com/netresearch/docker-development-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "docker-development",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Docker image development patterns for Dockerfile, docker-compose, docker-bake.hcl, and CI testing",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when working with ANY Docker task: writing Dockerfiles, config
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Requires docker, docker compose."
 metadata:
-  version: "1.12.0"
+  version: "1.13.0"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:

--- a/skills/docker-via-wsl/SKILL.md
+++ b/skills/docker-via-wsl/SKILL.md
@@ -4,7 +4,7 @@ description: "Use when YOU (the AI agent) are running on Windows OUTSIDE WSL (Gi
 license: "(MIT AND CC-BY-SA-4.0)"
 compatibility: "Windows host with Docker Desktop using the WSL2 backend."
 metadata:
-  version: "1.12.0"
+  version: "1.13.0"
   repository: "https://github.com/netresearch/docker-development-skill"
   author: "Netresearch DTT GmbH"
 allowed-tools:


### PR DESCRIPTION
Version bump to 1.13.0 for release: rolls the changelog where present and updates every version surface. No content changes beyond the release metadata.