### PR TITLE
docs(ci-testing): hadolint floating-latest policy — fix surfaced findings, never pin

### DIFF
--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -311,12 +311,15 @@ predates the failure and re-running it fails identically, the linter moved,
 not your change.
 
 Policy: treat the new finding as surfaced debt and fix it in the same MR —
-do not pin the hadolint image and do not add an ignore. Pinning hides every
-future rule improvement; the debt only grows.
+do not pin the hadolint image. A scoped `.hadolint.yaml` ignore is reserved
+for rules whose "fix" creates worse breakage — the canonical case is
+DL3008/DL3018 (pinning distro packages breaks on the next mirror sync) — and
+always carries a comment stating that rationale. Pinning the linter instead
+hides every future rule improvement; the debt only grows.
 
 Concrete case (2026-08-13, `docker/node-red`): a hadolint update started
 failing `DL3066` (non-numeric user-id) on `USER root` / `USER node-red`.
-Fix: use the numeric ids the image already establishes —
+Fix: use the numeric ids the Dockerfile already establishes —
 
 ```dockerfile
 USER 0
@@ -325,4 +328,6 @@ USER 10458
 ```
 
 No behavior change, and the id survives environments that cannot resolve
-container-internal user names.
+container-internal user names. (The `apk add` here stays unpinned under the
+DL3018 ignore above — that is the scoped exception in action, not a
+contradiction of it.)

--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -299,3 +299,30 @@ GNU coreutils on the host and busybox in an Alpine image disagree on more than
 this one case. A local check that passes proves the host's semantics, not the
 container's — and the difference surfaces as a gate that silently waves things
 through, which is the direction nobody notices.
+
+## Pattern 9: hadolint's floating `latest` is a feature — fix findings, don't pin
+
+CI lint jobs typically run `hadolint/hadolint:latest-alpine`. A hadolint
+release can turn a previously-quiet rule into a failure overnight, so an
+unrelated MR (a Renovate version bump, a docs change) suddenly goes red.
+
+Diagnose before blaming the diff: if the default branch's last green run
+predates the failure and re-running it fails identically, the linter moved,
+not your change.
+
+Policy: treat the new finding as surfaced debt and fix it in the same MR —
+do not pin the hadolint image and do not add an ignore. Pinning hides every
+future rule improvement; the debt only grows.
+
+Concrete case (2026-08-13, `docker/node-red`): a hadolint update started
+failing `DL3066` (non-numeric user-id) on `USER root` / `USER node-red`.
+Fix: use the numeric ids the image already establishes —
+
+```dockerfile
+USER 0
+RUN apk add --no-cache shadow && usermod -u 10458 node-red && apk del shadow
+USER 10458
+```
+
+No behavior change, and the id survives environments that cannot resolve
+container-internal user names.


### PR DESCRIPTION
A hadolint release turned DL3066 (non-numeric user-id) into a failure on an unrelated Renovate MR (`docker/node-red` !13, 2026-08-13). Adds to ci-testing.md: the diagnostic (default branch's last green predates the failure ⇒ the linter moved, not the diff), the policy (fix the surfaced debt in the same MR; never pin the linter image, never ignore), and the concrete numeric-UID fix.