### PR TITLE
docs(docker-development): registry push-RBAC, tag-existence, and debug-build leak notes

### DIFF
--- a/skills/docker-development/references/build-secret-leaks.md
+++ b/skills/docker-development/references/build-secret-leaks.md
@@ -61,3 +61,23 @@ rather than fail.
 Rotation is the only remedy that acts on what is already published — the
 attestations of existing versions keep their copy of the value forever, or until
 someone deletes those package versions. Rotate first, fix the build second.
+
+## The other leak: your own debugging session
+
+A leak does not need buildx provenance to happen. `docker build --progress=plain`
+(or any verbose/raw build log) echoes the literal `RUN` command line with every
+`ARG`/`ENV` already interpolated — so a credential-bearing build arg shows up in
+cleartext the moment that output reaches a terminal, a piped log file, or a
+`tail`. This is a transient leak (nothing gets published), but it lands directly
+in whatever you're capturing the session with — chat transcript, screen
+recording, CI job log — which is exactly the audience `--mount=type=secret` was
+meant to keep it from. It happens even when the project's real Dockerfile is
+already fixed with `--mount=type=secret`, because the leak comes from an ad-hoc
+debug invocation outside that path, not from the build definition.
+
+Treat it the same as a provenance leak once it happens: rotate the credential
+first, then clean up (delete the log file, prune the build cache — the layer
+with the interpolated value may still be cached locally even though it was
+never pushed). Avoid it by not running debug builds with secret-bearing `ARG`s
+through `--progress=plain`/verbose output that you then cat, tail, or pipe
+into something you'll read — redact the known secret value first if you must.

--- a/skills/docker-development/references/registry-catalogue-and-pin-rot.md
+++ b/skills/docker-development/references/registry-catalogue-and-pin-rot.md
@@ -78,3 +78,37 @@ that exemption is written down:
 - **Testing the tag against the literal string `latest`.** `latest-rolling`,
   `latest-alpine` and friends float exactly as much and sail through. Treat a
   `latest-*` or `edge-*` prefix as floating.
+
+## A tag that "should" exist can just not
+
+Don't assume a variant tag exists because the pattern is common elsewhere —
+check the catalogue the same way as above. `composer:2-alpine` is not a real
+tag: the official `composer` image is Alpine-based *at* `composer:2`, so the
+`-alpine` suffix some other images use has nothing to pull. A short,
+unqualified reference like `composer:2` in a `.env`/build-arg also fails
+differently depending on where it resolves: buildah/podman running
+non-interactively enforce short-name resolution and refuse to guess a
+registry, erroring with "short-name resolution enforced but cannot prompt
+without a TTY" instead of defaulting to Docker Hub. Fully qualify it
+(`docker.io/library/composer:2`) rather than relying on the short name to
+resolve the same way it does interactively.
+
+## A push failing "unauthorized" is a role question, not always a credential one
+
+`unauthorized to access repository: <repo>, action: push` from a private
+registry (Harbor and similar) usually reads like a login problem, so the
+instinct is to re-check the password and rebuild. Ask the registry's own RBAC
+API first instead of spending a full build+push cycle per guess — Harbor
+answers this in two read-only calls:
+
+```bash
+curl -s -u "$USER:$TOKEN" https://harbor.example.com/api/v2.0/users/current \
+  | jq '.username'
+curl -s -u "$USER:$TOKEN" "https://harbor.example.com/api/v2.0/projects/<id>/members" \
+  | jq '.[] | select(.entity_name=="'"$USER"'")'
+```
+
+A valid login with no membership entry (or `role_id: null`) for the target
+project means the account has zero role there — no amount of retrying the
+push fixes that; someone with project-admin/Maintainer needs to grant a role
+(Developer is enough to push).


### PR DESCRIPTION
## Summary

- Documents that a private-registry push "unauthorized" error is often a role/RBAC gap, not a credential problem, and how to check it in two read-only API calls instead of a rebuild-and-retry loop.
- Documents that a plausible variant tag (e.g. `composer:2-alpine`) can simply not exist, and that unqualified short image references fail hard under non-interactive buildah/podman short-name resolution.
- Documents a second, distinct secret-leak vector alongside the existing provenance-attestation one: ad-hoc debug builds (`--progress=plain`, piped/tailed logs) echo literal RUN commands with ARG/ENV already interpolated, leaking into whatever is capturing the session even when the project's real Dockerfile already uses `--mount=type=secret`.

## Came from

`/retro` session on 2026-08-13, working a TYPO3 buildbox modernization ticket (WSD-1336). All three facts were rediscovered live during that session; none were previously documented in this skill.

- **Symptom:** Harbor push failed with a generic `unauthorized ... action: push` despite correct credentials; `composer:2-alpine` failed to resolve; an ad-hoc debug build leaked a token into the session transcript.
- **Cause:** the account had no RBAC role on the target Harbor project (confirmed via the API, not by retrying the push); the `-alpine` tag variant does not exist for this image; `--progress=plain` output is not redacted and echoes interpolated build args.
- **Required behavior:** check registry RBAC via API before assuming a credential problem; verify a tag exists before assuming a naming convention holds; never pipe/tail verbose build output that carries secret-bearing ARGs.
- **Verification:** none automated (documentation-only reference addition); `skill-repo-skill`'s `validate-skill.sh` passes with 0 errors, SKILL.md unchanged at 500/500 words.

## Change

Two reference-file edits, no SKILL.md change (already at the 500-word cap):
- `references/build-secret-leaks.md`: new "The other leak: your own debugging session" section.
- `references/registry-catalogue-and-pin-rot.md`: new "A tag that 'should' exist can just not" and "A push failing 'unauthorized' is a role question, not always a credential one" sections.

## Test plan

- [x] `validate-skill.sh` run locally against the repo root: 0 errors
- [x] SKILL.md word count unchanged (500/500, no edit made there)
- [ ] Markdown lint (not run locally — no `markdownlint-cli2` binary available; content reviewed by eye against `.markdownlint-cli2.jsonc`)
