### PR TITLE
docs(ci-testing): add pattern for validating custom base-image changes

### DIFF
--- a/skills/docker-development/references/ci-testing.md
+++ b/skills/docker-development/references/ci-testing.md
@@ -331,3 +331,36 @@ No behavior change, and the id survives environments that cannot resolve
 container-internal user names. (The `apk add` here stays unpinned under the
 DL3018 ignore above — that is the scoped exception in action, not a
 contradiction of it.)
+
+## Pattern 10: Validating a change to a custom base image needs the real image, not a stand-in
+
+SKILL.md's "Mock upstream DNS" gotcha (`docker run --add-host backend:127.0.0.1
+nginx-image nginx -t`) assumes `nginx-image` really is the image under test.
+When the change under test lives in a *shared/base* image maintained
+elsewhere — one that compiles in extra modules or ships modified system
+files — substituting a generic public image of the same software (e.g.
+`nginx:alpine` in place of a custom nginx+PHP-FPM base image) produces
+unrelated, misleading errors instead of testing the actual change:
+
+```
+$ docker run --rm -v $PWD/rootfs/etc/nginx:/etc/nginx:ro nginx:alpine nginx -t
+nginx: [emerg] getpwnam("www-data") failed          # base has no www-data user
+...
+nginx: [emerg] open() "/etc/nginx/mime.types" failed # base ships mime.types elsewhere
+...
+nginx: [emerg] unknown directive "brotli"            # real image compiles brotli in, nginx:alpine doesn't
+```
+
+None of these are about the change under test — they're artifacts of the
+wrong base. Build or pull the actual image first, then run the check against
+it:
+
+```bash
+docker build --build-arg PHP_VERSION=84 -t custom-image:test .
+docker run --rm --add-host phpfpm:127.0.0.1 --entrypoint sh custom-image:test -c "nginx -t"
+```
+
+This costs one build (or pull, if the base is already published and registry
+auth is already configured), not a rewrite of the stand-in's `/etc/nginx` to
+patch in the missing pieces — that arms race never converges once the real
+base changes again.


### PR DESCRIPTION
## Summary

Adds Pattern 10 to `ci-testing.md`: when validating a change to a custom/shared base image, build or pull the real image rather than approximating it with a generic public image of the same software.

## Came from

`/retro` session on 2026-08-17, working `futuresax/main-14`/`support/typo3-14/t3re`.
Finding: verifying an nginx config change cost 3 failed attempts before landing on the right approach.
Learning-Id: retro-20260817-custom-base-image-verification

- **Symptom:** `docker run --add-host backend:127.0.0.1 nginx:alpine nginx -t` against a mounted config from a custom TYPO3 runtime image failed three times in a row with unrelated errors: missing `www-data` user, missing `mime.types`, `unknown directive "brotli"`.
- **Cause:** `nginx:alpine` doesn't have the compiled-in brotli module or modified base files the real image ships. SKILL.md's existing "Mock upstream DNS" gotcha already shows the right command, but implicitly assumes the image under test is the real one — it doesn't warn against substituting a generic stand-in for a custom base image.
- **Required behavior:** build/pull the actual image under test first, then run the config check against it.
- **Verification:** `bash scripts/verify-harness.sh` → Level 3 COMPLETE, 0 errors/warnings. Prose-only doc addition; no new command/recipe requiring its own eval.

## Change

`skills/docker-development/references/ci-testing.md`: new Pattern 10.

## Test plan

- [x] `bash scripts/verify-harness.sh`
- [ ] Reviewer confirms the failure-mode examples (`www-data`, `mime.types`, `brotli`) read as genuinely `nginx:alpine`-specific, not something the real fix should instead patch into the stand-in