### PR TITLE
test(evals): cover the healthcheck-disable trap that breaks compose --wait

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -523,5 +523,33 @@
         "description": "Identifies the SMB/network-drive path translation inside Docker Desktop's WSL2 backend as the root cause, not a Docker cache or single-file-bind-mount bug"
       }
     ]
+  },
+  {
+    "name": "healthcheck-disable-breaks-compose-wait",
+    "prompt": "My compose worker reuses the web image and was permanently unhealthy because it inherits that image's HEALTHCHECK for php-fpm, which the worker doesn't run. So I added `healthcheck: { disable: true }` to the worker. Now `docker compose up -d --wait` fails in CI. What is going on and how do I fix it?",
+    "assertions": [
+      {
+        "type": "content_regex",
+        "value": "no healthcheck configured|has no health ?check",
+        "description": "Names the compose failure mode: an explicitly listed service without a healthcheck cannot be waited on"
+      },
+      {
+        "type": "content_regex",
+        "value": "(?i)(real|proper|its own|working|actual) health ?check|health ?check .{0,40}instead|(don't|do not|never) disable",
+        "description": "Fixes it by giving the worker a health check of its own rather than disabling the inherited one"
+      },
+      {
+        "type": "content_regex",
+        "value": "(?i)inherit",
+        "description": "Explains that reusing the app image inherits its baked-in HEALTHCHECK, which is why the worker was unhealthy in the first place"
+      }
+    ],
+    "samples": {
+      "passing": "The worker inherits the web image's baked-in HEALTHCHECK, so it probes php-fpm and stays unhealthy. Disabling it does not help: compose refuses to wait on an explicitly listed service and reports 'container worker has no healthcheck configured'. Give the worker a real healthcheck of its own, e.g. a CMD-SHELL pgrep with a character-class guard, and verify it both ways.",
+      "failing": [
+        "Just drop the --wait flag from your docker compose up command and poll the logs instead; the worker does not need a healthcheck.",
+        "That is a Docker Desktop bug. Restart the daemon and rebuild the image with --no-cache."
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Closes this repo's part of the public checklist in [netresearch/skill-repo-skill#148](https://github.com/netresearch/skill-repo-skill/issues/148).

`references/ci-testing.md` documents three traps for a worker service that reuses the app image. Two already had evals — the inherited probe via `compose-healthcheck`, the `pgrep` self-match via `worker-healthcheck-pgrep-self-match`. The middle one had none, and it is the one that looks most like a fix: `healthcheck: { disable: true }` on a worker whose inherited check probes php-fpm, after which `docker compose up -d --wait` fails with `has no healthcheck configured`, because compose will not wait on an explicitly listed service without a check.

The new eval asserts the failure mode, the fix (a check of the worker's own, not `disable`), and the inheritance that caused the unhealthy state to begin with. It carries `samples`, so `validate-evals.sh` proves mechanically that a correct answer satisfies every assertion and that two plausible wrong answers — drop `--wait`, blame Docker Desktop — are each rejected.

No `must_not` assertion, deliberately: `run-ab-evals.sh` greps every assertion with no type filter, so a `must_not` is graded as a *positive* match and would inflate the baseline arm. The negative case lives in `samples.failing`, which the validator does check inverted. (Filed against the runner separately.)

The other item #148 lists for this repo — a first eval for `docker-via-wsl` asserting the `wsl.exe -e bash -lc` re-issue — landed earlier as `docker-via-wsl-reissue-not-windows-shell`, so this completes the repo.

**Verified locally:** `validate-evals.sh evals/evals.json` → 55 passed, 0 failed, 0 warnings (including the `samples` self-check on the new eval), and `pre-commit run --files evals/evals.json` green.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
