### PR TITLE
docs(compose): single-definition image ref via extension field + anchor

### DIFF
--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -126,6 +126,7 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 - startup ordering: `depends_on.condition: service_healthy` + `healthcheck` `start_period`
 - `networks.internal: true` isolates databases
 - `profiles: [debug]`: start only with `--profile debug`
+- shared image ref: define ONCE per file as top-level extension field + anchor -- `x-app-image: &app-image registry/app:${APP_IMAGE_VERSION:-85}`, services use `image: *app-image`. `:-` defaults cover unset AND empty vars (a bare omitted tag silently resolves `:latest`). Anchors are file-local: every overlay file needs its own. Verify both paths: `APP_IMAGE_VERSION= docker compose config` and with an override
 
 ## References
 

--- a/skills/docker-development/SKILL.md
+++ b/skills/docker-development/SKILL.md
@@ -126,7 +126,7 @@ Exclude: `.git`, `node_modules`/`vendor`, `.env*`, `*.pem`, `*.key`
 - startup ordering: `depends_on.condition: service_healthy` + `healthcheck` `start_period`
 - `networks.internal: true` isolates databases
 - `profiles: [debug]`: start only with `--profile debug`
-- shared image ref: define ONCE per file as top-level extension field + anchor -- `x-app-image: &app-image registry/app:${APP_IMAGE_VERSION:-85}`, services use `image: *app-image`. `:-` defaults cover unset AND empty vars (a bare omitted tag silently resolves `:latest`). Anchors are file-local: every overlay file needs its own. Verify both paths: `APP_IMAGE_VERSION= docker compose config` and with an override
+- shared image ref: define ONCE per file as top-level extension field + anchor -- `x-app-image: &app-image registry/app:${APP_IMAGE_VERSION:-85}`, services use `image: *app-image`. The field must sit ABOVE `services:` — an alias is only valid after its anchor in document order. `:-` defaults cover unset AND empty vars (a bare omitted tag silently resolves `:latest`). Anchors are file-local: every overlay file needs its own. Verify both paths: `APP_IMAGE_VERSION= docker compose config` and with an override
 
 ## References
 


### PR DESCRIPTION
Adds one Compose Essentials bullet: define a shared image reference (path + version variable + default tag) once per compose file as a top-level `x-*` extension field with a YAML anchor, referenced by the services via `image: *anchor`. Documents the two traps met in practice on OPS-898 across nine consumer repos: anchors are file-local (every overlay needs its own), and only `${VAR:-def}` also catches the empty-but-set variable — a bare omitted tag silently resolves `:latest`. Verification recipe via `docker compose config` for both the default and the override path.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01Mu33BP3JtQfKkpZkeTHLqr)_

**Review round.** Added the third trap: the `x-*` field must sit above `services:`, because a YAML alias is only valid after its anchor in document order — go-yaml rejects the other order with `unknown anchor`. All four paths verified with `docker compose config` v5.4.0: default, empty-but-set, override, and anchor-after-alias.

_Review round assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Txqmch9od8QmcXqPyVJ7bD)_
